### PR TITLE
Add size attribute to lmv-viewer component

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,15 @@
 
   <lmv-viewer url="http://lmv.rocks/data/engineraw/0.svf"></lmv-viewer>
 
+  <p>Models to load</p>
   <p><a href="#" data-url="http://lmv.rocks/data/engineraw/0.svf">Engine</a></p>
   <p><a href="#" data-url="http://lmv.rocks/data/rally/1/RallyFighter2.svf">Rally Fighter</a></p>
   <p><a href="#" data-url="http://lmv.rocks/data/gears/output/bubble.json">Diff Gears</a></p>
+  <br>
+  <p>Multiple sizes</p>
+  <p><a href="#" data-size="400x300">400x300</a></p>
+  <p><a href="#" data-size="600x400">600x400</a></p>
+  <p><a href="#" data-size="800x600">800x600</a></p>
 
 <script>
 (function() {
@@ -29,7 +35,11 @@
 
   Array.prototype.forEach.call(document.querySelectorAll("a"), function(elem) {
     elem.addEventListener("click", function() {
-      viewerElem.setAttribute("url", this.dataset.url);
+      if ('url' in this.dataset) {
+        viewerElem.setAttribute("url", this.dataset.url);
+      } else if ('size' in this.dataset) {
+        viewerElem.setAttribute("size", this.dataset.size);
+      }
     });
   });
 

--- a/lmv-viewer.html
+++ b/lmv-viewer.html
@@ -89,6 +89,7 @@
 
     this.ready = false;                   // ready to load url
     this.url = this.getAttribute("url");  // url to load
+    var sizePx = this.getAttribute("size"); // Format: <width>x<height>. Example: "600x400"
 
     this.doc = undefined;                 // reference to av.Document, if exists
 
@@ -97,6 +98,8 @@
       this.env = "Local";
       this.setAttribute("env", "Local");  // reflect in attr
     }                                     // TODO_NOP: but results in ugly case in envChanged()
+
+    this.sizeChanged(null, sizePx);
 
     var token = this.getAttribute("token");
 
@@ -144,6 +147,20 @@
     }, {accessToken: newVal});
   };
 
+  element.sizeChanged = function(oldVal, newVal) {
+      if (!newVal) return;
+      var parts = newVal.split('x');
+      if (parts.length !== 2) return;
+      var pxWidth = Number(parts[0]);
+      var pxHeight = Number(parts[1]);
+      if (pxWidth)
+        this.style.width = pxWidth + 'px';
+      if (pxHeight)
+        this.style.height = pxHeight + 'px';
+      if (pxWidth || pxHeight) {
+        this.viewer && this.viewer.resize();
+      }
+  };
 
 
   //---------------------------------------------------------


### PR DESCRIPTION
This change adds the ability for users to update the canvas size of lmv at
start-up and in run-time.

lmv-viewer will now track changes in attribute 'size'
size has a format of <width>x<height>. Example: size="800x600"
The idea behind this approach is to have an atomic operation for size change,
instead of separate changes to width and height which I believe will
probably come one after the other in most use cases.

In addition, the index page has been updated with options to change the
canvas size in runtime.
